### PR TITLE
cd into helloworld as part of workspace start

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,8 @@ image:
   file: .gitpod.Dockerfile
 tasks:
   - name: Build helloworld
-    init: cd helloworld && dune build
+    before: cd helloworld
+    init: dune build
     command: |
       eval $(opam env)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@
 
 This is a [OCaml](https://en.wikipedia.org/wiki/OCaml) template configured for ephemeral development environments on [Gitpod](https://www.gitpod.io/). It provides the development tools recommneded in the offical OCaml documentation: [Up and Running with OCaml](https://ocaml.org/learn/tutorials/up_and_running.html): It uses [Dune](https://dune.readthedocs.io/en/stable/) as the build system, [ocaml-lsp](https://github.com/ocaml/ocaml-lsp) to provide code-completion etc, and [ocamlformat](https://github.com/ocaml-ppx/ocamlformat) to automatically format your code whenever you save files.
 
-To build and run the helloworld program, run the following from inside the `helloworld` folder:
+Before you can build and run the helloworld program you need to be in the right directory and have the opam environment configured; in Gitpod this is already done for you.
+
+```sh
+cd helloworld
+eval $(opam env)
+```
+
+To build and run the helloworld program, run the following:
 
 ```sh
 dune build

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a [OCaml](https://en.wikipedia.org/wiki/OCaml) template configured for ephemeral development environments on [Gitpod](https://www.gitpod.io/). It provides the development tools recommneded in the offical OCaml documentation: [Up and Running with OCaml](https://ocaml.org/learn/tutorials/up_and_running.html): It uses [Dune](https://dune.readthedocs.io/en/stable/) as the build system, [ocaml-lsp](https://github.com/ocaml/ocaml-lsp) to provide code-completion etc, and [ocamlformat](https://github.com/ocaml-ppx/ocamlformat) to automatically format your code whenever you save files.
 
-To build and run the helloworld program, run the following:
+To build and run the helloworld program, run the following from inside the `helloworld` folder:
 
 ```sh
 dune build


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This improves the README by making the build and run instructions better and improves the Gitpod config by ensuring the user's shell session is already in the right directory.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

No issue

## How to test
<!-- Provide steps to test this PR -->

1. Start a workspace
2. `dune build && dune exec ./helloworld.exe` should build and execute the helloworld program

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A